### PR TITLE
Stabilize SENTINAL CLI import paths and add deterministic ingest->ask integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
-# Flash-AI (Initial Scaffold)
+# SENTINAL + Flash-AI
 
-This repository now contains an initial, runnable Python scaffold for Flash-AI:
+This repository contains two local-first Python components:
 
-- `flash_ai.engine`: deterministic flashcard generation logic
-- `flash_ai.service`: application service layer with in-memory deck storage
-- `flash_ai.models`: core domain models
-- `tests/`: starter tests for generation and service behavior
+- `sentinal`: offline ingestion/index/search/QA pipeline with a Click CLI.
+- `flash_ai`: deterministic flashcard generation scaffold.
 
-## Why this scaffold
+## SENTINAL quickstart
 
-The file `Flash-AI_Technical-Design-Manual-(TDM).PDF` currently has zero bytes in this repository,
-so this scaffold establishes a clean foundation that can be aligned to the full TDM once the
-manual content is available.
+Run CLI commands with `PYTHONPATH=src`:
+
+```bash
+PYTHONPATH=src python -m sentinal.cli_py init
+PYTHONPATH=src python -m sentinal.cli_py ingest ./docs/notes.md
+PYTHONPATH=src python -m sentinal.cli_py search "offline first"
+PYTHONPATH=src python -m sentinal.cli_py ask "What does SENTINAL do?"
+```
+
+You can switch to JSON output with `--json` and choose config profiles (`dev`, `prod`, `airgap`, `edge_lowmem`) via `--profile`.
 
 ## Run tests
 
 ```bash
-python -m pytest -q
+PYTHONPATH=src python -m pytest -q
 ```

--- a/src/sentinal/adapters.py
+++ b/src/sentinal/adapters.py
@@ -1,0 +1,19 @@
+"""Compatibility exports for source adapters."""
+
+from .adapters_py import (
+    BaseAdapter,
+    DocumentRecord,
+    MarkdownAdapter,
+    PdfAdapter,
+    TxtAdapter,
+    get_adapter,
+)
+
+__all__ = [
+    "BaseAdapter",
+    "DocumentRecord",
+    "MarkdownAdapter",
+    "PdfAdapter",
+    "TxtAdapter",
+    "get_adapter",
+]

--- a/src/sentinal/chunker.py
+++ b/src/sentinal/chunker.py
@@ -1,0 +1,5 @@
+"""Compatibility exports for chunking logic."""
+
+from .chunker_py import Chunk, Strategy, chunk_document
+
+__all__ = ["Chunk", "Strategy", "chunk_document"]

--- a/src/sentinal/config.py
+++ b/src/sentinal/config.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from .config_py import SentinalConfig, load_config
+
 
 @dataclass(frozen=True, slots=True)
 class SentinalPaths:
@@ -31,3 +33,11 @@ class RetrievalConfig:
     chunk_size: int = 500
     chunk_overlap: int = 50
     top_k: int = 4
+
+
+__all__ = [
+    "RetrievalConfig",
+    "SentinalConfig",
+    "SentinalPaths",
+    "load_config",
+]

--- a/src/sentinal/doctor.py
+++ b/src/sentinal/doctor.py
@@ -1,0 +1,5 @@
+"""Compatibility exports for doctor checks."""
+
+from .doctor_py import CheckResult, DoctorReport, run_doctor
+
+__all__ = ["CheckResult", "DoctorReport", "run_doctor"]

--- a/src/sentinal/doctor_py.py
+++ b/src/sentinal/doctor_py.py
@@ -44,13 +44,16 @@ class DoctorReport:
 
 
 def run_doctor(config: SentinalConfig) -> DoctorReport:
-    """Run all health checks and return a DoctorReport.
-
-    Args:
-        config: Validated SentinalConfig.
-
+    """
+    Perform a set of system and configuration health checks.
+    
+    Checks include: Python runtime version, data directory presence, available disk space, metadata SQLite DB presence, index directory presence, availability of optional dependencies (pypdf, numpy, tomli), and index integrity if an index exists.
+    
+    Parameters:
+        config (SentinalConfig): Application configuration containing paths (data_dir, db_path, index_path) used for checks.
+    
     Returns:
-        DoctorReport with individual check results.
+        DoctorReport: Report containing individual CheckResult entries for each performed check.
     """
     report = DoctorReport()
 

--- a/src/sentinal/doctor_py.py
+++ b/src/sentinal/doctor_py.py
@@ -123,7 +123,7 @@ def run_doctor(config: SentinalConfig) -> DoctorReport:
 
     # 7. Index integrity (if index exists)
     if idx_ok:
-        from sentinal.index import VectorIndex
+        from sentinal.index_py import VectorIndex
         try:
             vi = VectorIndex(index_dir=config.index_path)
             issues = vi.integrity_check()

--- a/src/sentinal/errors.py
+++ b/src/sentinal/errors.py
@@ -1,0 +1,23 @@
+"""Compatibility exports for SENTINAL domain errors."""
+
+from .errors_py import (
+    ChunkingError,
+    ConfigError,
+    IndexError,
+    IngestionError,
+    QAError,
+    SearchError,
+    SentinalError,
+    StorageError,
+)
+
+__all__ = [
+    "ChunkingError",
+    "ConfigError",
+    "IndexError",
+    "IngestionError",
+    "QAError",
+    "SearchError",
+    "SentinalError",
+    "StorageError",
+]

--- a/src/sentinal/logging_utils.py
+++ b/src/sentinal/logging_utils.py
@@ -1,0 +1,5 @@
+"""Compatibility exports for logging helpers."""
+
+from .logging_py import configure_logging, get_logger, timed_log
+
+__all__ = ["configure_logging", "get_logger", "timed_log"]

--- a/src/sentinal/pipeline.py
+++ b/src/sentinal/pipeline.py
@@ -1,0 +1,5 @@
+"""Compatibility exports for SENTINAL pipeline."""
+
+from .pipeline_py import Pipeline
+
+__all__ = ["Pipeline"]

--- a/src/sentinal/pipeline_py.py
+++ b/src/sentinal/pipeline_py.py
@@ -10,7 +10,7 @@ from sentinal.adapters import get_adapter
 from sentinal.chunker import Chunk, Strategy, chunk_document
 from sentinal.config import SentinalConfig
 from sentinal.errors import IngestionError, QAError
-from sentinal.index import Embedder, VectorIndex
+from sentinal.index_py import Embedder, VectorIndex
 from sentinal.logging_utils import get_logger, timed_log
 from sentinal.storage import MetadataStore
 

--- a/src/sentinal/storage.py
+++ b/src/sentinal/storage.py
@@ -1,0 +1,5 @@
+"""Compatibility exports for metadata storage."""
+
+from .storage_py import MetadataStore
+
+__all__ = ["MetadataStore"]

--- a/tests/test_sentinal_pipeline_cli.py
+++ b/tests/test_sentinal_pipeline_cli.py
@@ -32,6 +32,15 @@ def test_pipeline_ingest_search_ask_is_deterministic(tmp_path: Path) -> None:
 
 
 def test_cli_init_ingest_search_and_ask_json_output(tmp_path: Path) -> None:
+    """
+    Run the CLI end-to-end in JSON mode to validate init, ingest, search, and ask workflows.
+    
+    Executes the CLI with a temporary data directory and a sample source file, then:
+    - Initializes the profile and asserts the returned status is "initialised".
+    - Ingests the sample file and asserts the payload indicates it was not skipped.
+    - Performs a search for "ingestion" and asserts the search payload is non-empty.
+    - Asks "What does SENTINAL include?" and asserts the response is grounded and includes sources.
+    """
     runner = CliRunner()
     data_dir = tmp_path / "state"
     source = tmp_path / "notes.md"

--- a/tests/test_sentinal_pipeline_cli.py
+++ b/tests/test_sentinal_pipeline_cli.py
@@ -1,0 +1,71 @@
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from sentinal.cli_py import cli
+from sentinal.config import SentinalConfig
+from sentinal.pipeline import Pipeline
+
+
+def test_pipeline_ingest_search_ask_is_deterministic(tmp_path: Path) -> None:
+    data_dir = tmp_path / ".sentinal"
+    cfg = SentinalConfig(data_dir=data_dir)
+    source = tmp_path / "baseline.txt"
+    source.write_text(
+        "SENTINAL works offline first. It ingests local files and retrieves relevant chunks for answers.",
+        encoding="utf-8",
+    )
+
+    first = Pipeline(cfg)
+    ingest_result = first.ingest(source)
+    first_answer = first.ask("How does SENTINAL work?")
+
+    second = Pipeline(cfg)
+    second_answer = second.ask("How does SENTINAL work?")
+
+    assert ingest_result["skipped"] is False
+    assert ingest_result["chunk_count"] >= 1
+    assert first_answer["grounded"] is True
+    assert first_answer["answer"] == second_answer["answer"]
+    assert first_answer["sources"] == second_answer["sources"]
+
+
+def test_cli_init_ingest_search_and_ask_json_output(tmp_path: Path) -> None:
+    runner = CliRunner()
+    data_dir = tmp_path / "state"
+    source = tmp_path / "notes.md"
+    source.write_text("SENTINAL includes ingestion, indexing, and ask commands.", encoding="utf-8")
+
+    init_result = runner.invoke(cli, ["--json", "--profile", "dev", "init"], env={"SENTINAL_DATA_DIR": str(data_dir), "SENTINAL_LOG_LEVEL": "CRITICAL"})
+    assert init_result.exit_code == 0
+    init_payload = json.loads(init_result.output)
+    assert init_payload["status"] == "initialised"
+
+    ingest_result = runner.invoke(
+        cli,
+        ["--json", "ingest", str(source)],
+        env={"SENTINAL_DATA_DIR": str(data_dir), "SENTINAL_LOG_LEVEL": "CRITICAL"},
+    )
+    assert ingest_result.exit_code == 0
+    ingest_payload = json.loads(ingest_result.output)
+    assert ingest_payload["skipped"] is False
+
+    search_result = runner.invoke(
+        cli,
+        ["--json", "search", "ingestion"],
+        env={"SENTINAL_DATA_DIR": str(data_dir), "SENTINAL_LOG_LEVEL": "CRITICAL"},
+    )
+    assert search_result.exit_code == 0
+    search_payload = json.loads(search_result.output)
+    assert search_payload
+
+    ask_result = runner.invoke(
+        cli,
+        ["--json", "ask", "What does SENTINAL include?"],
+        env={"SENTINAL_DATA_DIR": str(data_dir), "SENTINAL_LOG_LEVEL": "CRITICAL"},
+    )
+    assert ask_result.exit_code == 0
+    ask_payload = json.loads(ask_result.output)
+    assert ask_payload["grounded"] is True
+    assert ask_payload["sources"]


### PR DESCRIPTION
### Motivation
- Make the new CLI/pipeline code importable using stable `sentinal.*` module names so the CLI entrypoint works when run via `PYTHONPATH=src`.
- Keep the hardened config/loading implementation available to the CLI while preserving existing retrieval config and path types for backward compatibility.
- Add a deterministic ingest→index→ask integration test and a JSON CLI flow test to validate persistence and repeatable answers for the baseline pipeline.

### Description
- Added compatibility bridge modules that re-export the `_py` implementations under stable names: `src/sentinal/adapters.py`, `src/sentinal/chunker.py`, `src/sentinal/doctor.py`, `src/sentinal/errors.py`, `src/sentinal/logging_utils.py`, `src/sentinal/pipeline.py`, and `src/sentinal/storage.py`.
- Updated `src/sentinal/config.py` to re-export `SentinalConfig` and `load_config` from the hardened config implementation while keeping `RetrievalConfig` and `SentinalPaths` types for consumers.
- Wired the runtime pipeline and doctor to the persistent/hybrid index implementation by importing `VectorIndex` from `sentinal.index_py` while retaining the legacy in-memory `sentinal.index` used by existing KnowledgeBase tests.
- Added `tests/test_sentinal_pipeline_cli.py` integration tests that exercise `init`, `ingest`, `search`, and `ask` in JSON mode, and refreshed `README.md` with quickstart usage using `PYTHONPATH=src`.

### Testing
- Ran `PYTHONPATH=src pytest -q` which resulted in `6 passed` and the new integration tests succeeded.
- Ran `PYTHONPATH=src python -m sentinal.cli_py --help` and verified the CLI help renders correctly.
- The new integration test file is `tests/test_sentinal_pipeline_cli.py` and it passed under the test run described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a752f6f55c832d9741d40d74766b6d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project branding to "SENTINAL + Flash-AI"
  * Added SENTINAL quickstart with CLI usage and JSON output instructions

* **New Features**
  * Added CLI commands: init, ingest, search, ask
  * Added JSON output mode and profile selection via --profile

* **Tests**
  * Added tests for deterministic pipeline behavior and end-to-end CLI workflows (JSON mode)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->